### PR TITLE
Fixed padding on games page for Enter game Lobby button

### DIFF
--- a/app/src/main/java/com/group_7/studysage/ui/screens/GameScreen/GameScreen.kt
+++ b/app/src/main/java/com/group_7/studysage/ui/screens/GameScreen/GameScreen.kt
@@ -48,7 +48,8 @@ fun GameScreen(navController: NavController) {
                 .fillMaxSize()
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 30.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // Header
@@ -151,6 +152,7 @@ fun GameScreen(navController: NavController) {
                         navController.navigate("game_play/$code")
                     }
                 )
+                Spacer(modifier = Modifier.height(30.dp))
             }
         }
 


### PR DESCRIPTION
- Enter Game lobby was not clickable due to navbar.
- Fixed it by adding adding at the bottom.